### PR TITLE
Feat/update GitHub commit status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+.token

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ venv\Scripts\activate  # On Windows
 pip install -r requirements.txt
 ```
 
+### **4. Create and set .token file**
+The `.token` file will contain the access token needed to authorize updating the commit status on GitHub. 
+It should be located in the base folder.
+Instructions on creating a token file can be found [here](https://github.com/settings/tokens). 
+If you're using a fine-grained token, it needs to be given "write" access to "Commit statuses".
+
+NOTE: The token is secret to you. DO NOT PUSH IT. It has been added to the `.gitignore` for this reason.
+
 ## Running the CI Server
 ```sh
 bash scripts/start_server.sh

--- a/src/ci_server.py
+++ b/src/ci_server.py
@@ -1,7 +1,6 @@
 import logging
 from flask import Flask, request, jsonify
-from webhook_handler import process_webhook
-from notifier import send_notification
+import system_routines, notifier
 
 # Initialize Flask app for webhook handling
 app = Flask(__name__)
@@ -10,9 +9,23 @@ app = Flask(__name__)
 @app.route("/webhook", methods=["POST"])
 def handle_webhook():
     """Handles incoming webhook events from GitHub and triggers necessary actions."""
-    payload = request.json
-    response = process_webhook(payload)
-    return response
+    data = request.get_json()
+    
+    
+    """Run tests"""
+    # system_routines.clone_and_run(data)
+    # Notify users
+    notifier.send_notification("success", 
+                               data['repository']['full_name'],
+                                # This only checks latest commit in a push
+                               data['head_commit']['id'],
+                               open("/mnt/s/year4/swe/ci_server/.token", "r").read(),
+                               None) 
+    
+    
+    return jsonify({"message": "Received update, running tests"}), 200
+
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)

--- a/src/ci_server.py
+++ b/src/ci_server.py
@@ -1,5 +1,6 @@
 import logging
 from flask import Flask, request, jsonify
+from pathlib import Path
 import system_routines, notifier
 
 # Initialize Flask app for webhook handling
@@ -15,11 +16,12 @@ def handle_webhook():
     """Run tests"""
     # system_routines.clone_and_run(data)
     # Notify users
+    token_path = Path(__file__).parent / "../.token"
     notifier.send_notification("success", 
                                data['repository']['full_name'],
                                 # This only checks latest commit in a push
                                data['head_commit']['id'],
-                               open("/mnt/s/year4/swe/ci_server/.token", "r").read(),
+                               open(token_path, "r").read(),
                                None) 
     
     

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -1,18 +1,63 @@
 import logging
+import requests
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
 
-# Placeholder for sending commit status updates to GitHub
 def send_commit_status(repo, commit_sha, status, token):
     """Sends a commit status update to GitHub."""
-    logging.info(f"Sending commit status update: {status} for {commit_sha} in {repo}")
-    pass
+    url = f"https://api.github.com/repos/{repo}/statuses/{commit_sha}"
+    
+    if status == "success":
+        state = "success"
+        description = "CI build succeeded!"
+    elif status == "failure":
+        state = "failure"
+        description = "CI build failed."
+    else:
+        state = "pending"
+        description = "CI build in progress..."
 
-# Placeholder for sending email notifications
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json"
+    }
+
+    data = {
+        "state": state,
+        "description": description,
+        "context": "continuous-integration/custom-ci",
+        "target_url": f"https://github.com/{repo}/actions"
+    }
+
+    try:
+        response = requests.post(url, headers=headers, json=data)
+        if response.status_code == 201:
+            logging.info(f"Successfully updated commit status for {commit_sha}")
+        else:
+            logging.error(f"Failed to update commit status. Status code: {response.status_code}")
+            logging.error(f"Response: {response.text}")
+    except Exception as e:
+        logging.error(f"Error sending commit status: {str(e)}")
+
 def send_email_notification(recipient, subject, message, smtp_server, smtp_port, sender_email, sender_password):
     """Sends an email notification with build results."""
-    logging.info(f"Sending email to {recipient} with subject: {subject}")
-    pass
+    msg = MIMEMultipart()
+    msg['From'] = sender_email
+    msg['To'] = recipient
+    msg['Subject'] = subject
+    msg.attach(MIMEText(message, 'plain'))
 
-# Central function for notification handling
+    try:
+        server = smtplib.SMTP(smtp_server, smtp_port)
+        server.starttls()
+        server.login(sender_email, sender_password)
+        server.send_message(msg)
+        server.quit()
+        logging.info(f"Successfully sent email to {recipient}")
+    except Exception as e:
+        logging.error(f"Error sending email: {str(e)}")
+
 def send_notification(status, repo=None, commit_sha=None, token=None, email_config=None):
     """Handles sending notifications (commit status or email) based on config."""
     logging.info(f"Processing notification with status: {status}")
@@ -23,11 +68,25 @@ def send_notification(status, repo=None, commit_sha=None, token=None, email_conf
     
     # Send email notification if email configuration is provided
     if email_config:
-        send_email_notification(
-            recipient=email_config.get("recipient"),
-            subject=f"CI Build Status: {status}",
-            message=f"The latest CI build has completed with status: {status}",
-            smtp_server=email_config.get("smtp_server"),
-            smtp_port=email_config.get("smtp_port"),
-            sender_email=email_config.get("sender_email"),
-            sender_pas
+        message = f"""
+CI Build Notification
+
+Status: {status}
+Repository: {repo}
+Commit: {commit_sha}
+
+For more details, please check the repository.
+"""
+        
+        try:
+            send_email_notification(
+                recipient=email_config.get("recipient"),
+                subject=f"CI Build Status: {status}",
+                message=message,
+                smtp_server=email_config.get("smtp_server"),
+                smtp_port=email_config.get("smtp_port"),
+                sender_email=email_config.get("sender_email"),
+                sender_password=email_config.get("sender_password")
+            )
+        except Exception as e:
+            logging.error(f"Failed to send email notification: {str(e)}")

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -19,7 +19,7 @@ def send_commit_status(repo, commit_sha, status, token):
         description = "CI build in progress..."
 
     headers = {
-        "Authorization": f"token {token}",
+        "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github.v3+json"
     }
 
@@ -63,30 +63,30 @@ def send_notification(status, repo=None, commit_sha=None, token=None, email_conf
     logging.info(f"Processing notification with status: {status}")
     
     # Send commit status update if repository details are provided
-    if repo and commit_sha and token:
-        send_commit_status(repo, commit_sha, status, token)
+    #if repo and commit_sha and token:
+    send_commit_status(repo, commit_sha, status, token)
     
-    # Send email notification if email configuration is provided
-    if email_config:
-        message = f"""
-CI Build Notification
-
-Status: {status}
-Repository: {repo}
-Commit: {commit_sha}
-
-For more details, please check the repository.
-"""
-        
-        try:
-            send_email_notification(
-                recipient=email_config.get("recipient"),
-                subject=f"CI Build Status: {status}",
-                message=message,
-                smtp_server=email_config.get("smtp_server"),
-                smtp_port=email_config.get("smtp_port"),
-                sender_email=email_config.get("sender_email"),
-                sender_password=email_config.get("sender_password")
-            )
-        except Exception as e:
-            logging.error(f"Failed to send email notification: {str(e)}")
+#     # Send email notification if email configuration is provided
+#     if email_config:
+#         message = f"""
+# CI Build Notification
+# 
+# Status: {status}
+# Repository: {repo}
+# Commit: {commit_sha}
+# 
+# For more details, please check the repository.
+# """
+#         
+#         try:
+#             send_email_notification(
+#                 recipient=email_config.get("recipient"),
+#                 subject=f"CI Build Status: {status}",
+#                 message=message,
+#                 smtp_server=email_config.get("smtp_server"),
+#                 smtp_port=email_config.get("smtp_port"),
+#                 sender_email=email_config.get("sender_email"),
+#                 sender_password=email_config.get("sender_password")
+#             )
+#         except Exception as e:
+#             logging.error(f"Failed to send email notification: {str(e)}")

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -63,30 +63,30 @@ def send_notification(status, repo=None, commit_sha=None, token=None, email_conf
     logging.info(f"Processing notification with status: {status}")
     
     # Send commit status update if repository details are provided
-    #if repo and commit_sha and token:
-    send_commit_status(repo, commit_sha, status, token)
+    if repo and commit_sha and token:
+        send_commit_status(repo, commit_sha, status, token)
     
-#     # Send email notification if email configuration is provided
-#     if email_config:
-#         message = f"""
-# CI Build Notification
-# 
-# Status: {status}
-# Repository: {repo}
-# Commit: {commit_sha}
-# 
-# For more details, please check the repository.
-# """
-#         
-#         try:
-#             send_email_notification(
-#                 recipient=email_config.get("recipient"),
-#                 subject=f"CI Build Status: {status}",
-#                 message=message,
-#                 smtp_server=email_config.get("smtp_server"),
-#                 smtp_port=email_config.get("smtp_port"),
-#                 sender_email=email_config.get("sender_email"),
-#                 sender_password=email_config.get("sender_password")
-#             )
-#         except Exception as e:
-#             logging.error(f"Failed to send email notification: {str(e)}")
+    # Send email notification if email configuration is provided
+    if email_config:
+        message = f"""
+            CI Build Notification
+            
+            Status: {status}
+            Repository: {repo}
+            Commit: {commit_sha}
+            
+            For more details, please check the repository.
+            """
+         
+        try:
+            send_email_notification(
+                recipient=email_config.get("recipient"),
+                subject=f"CI Build Status: {status}",
+                message=message,
+                smtp_server=email_config.get("smtp_server"),
+                smtp_port=email_config.get("smtp_port"),
+                sender_email=email_config.get("sender_email"),
+                sender_password=email_config.get("sender_password")
+            )
+        except Exception as e:
+            logging.error(f"Failed to send email notification: {str(e)}")

--- a/src/webhook_handler.py
+++ b/src/webhook_handler.py
@@ -1,8 +1,19 @@
 import logging
+import json
 from flask import request, jsonify
 from notifier import send_notification
+import os
 
-# Placeholder for webhook processing
+def get_user_email(username):
+    """Get user's email from environment variable mapping."""
+    try:
+        # Load email mappings from environment variable
+        email_mappings = json.loads(os.environ.get('USER_EMAIL_MAPPING', '{}'))
+        return email_mappings.get(username, os.environ.get('DEFAULT_RECIPIENT'))
+    except json.JSONDecodeError:
+        logging.error("Failed to parse USER_EMAIL_MAPPING environment variable")
+        return os.environ.get('DEFAULT_RECIPIENT')
+
 def process_webhook(payload):
     """Processes the webhook event received from GitHub and triggers necessary actions."""
     event_type = request.headers.get("X-GitHub-Event", "Unknown")
@@ -16,29 +27,106 @@ def process_webhook(payload):
         logging.warning(f"Unhandled event type: {event_type}")
         return jsonify({"message": "Event not handled."}), 400
 
-# Placeholder for handling push events
 def handle_push_event(payload):
     """Handles push events from GitHub webhook by triggering compilation, testing, and notification."""
-    compile_project()
-    test_results = run_tests()
-    send_notification(test_results)
-    return jsonify({"message": "Push event processed."}), 200
+    try:
+        repo_name = payload['repository']['full_name']
+        commit_sha = payload['after']
+        
+        # Get username and email of person who pushed
+        username = payload.get('pusher', {}).get('name')
+        recipient_email = get_user_email(username)
+        
+        # Send initial pending notification
+        send_notification(
+            status="pending",
+            repo=repo_name,
+            commit_sha=commit_sha,
+            token=os.environ.get('GITHUB_TOKEN')
+        )
+        
+        # Run tests and get results
+        success, test_message = run_tests()
+        
+        # Send final notification
+        send_notification(
+            status="success" if success else "failure",
+            repo=repo_name,
+            commit_sha=commit_sha,
+            token=os.environ.get('GITHUB_TOKEN'),
+            email_config={
+                "recipient": recipient_email,
+                "smtp_server": os.environ.get('SMTP_SERVER'),
+                "smtp_port": int(os.environ.get('SMTP_PORT')),
+                "sender_email": os.environ.get('SENDER_EMAIL'),
+                "sender_password": os.environ.get('EMAIL_PASSWORD')
+            },
+            message=test_message
+        )
+        
+        return jsonify({
+            "message": "Push event processed.",
+            "test_success": success,
+            "test_message": test_message
+        }), 200
+        
+    except Exception as e:
+        logging.error(f"Error processing push event: {str(e)}")
+        return jsonify({"error": str(e)}), 500
 
-# Placeholder for handling pull request events
 def handle_pull_request_event(payload):
     """Handles pull request events from GitHub webhook by running tests and notifying results."""
-    test_results = run_tests()
-    send_notification(test_results)
-    return jsonify({"message": "Pull request event processed."}), 200
+    try:
+        repo_name = payload['repository']['full_name']
+        commit_sha = payload['pull_request']['head']['sha']
+        
+        # Get username and email of person who created the PR
+        username = payload.get('pull_request', {}).get('user', {}).get('login')
+        recipient_email = get_user_email(username)
+        
+        # Send initial pending notification
+        send_notification(
+            status="pending",
+            repo=repo_name,
+            commit_sha=commit_sha,
+            token=os.environ.get('GITHUB_TOKEN')
+        )
+        
+        # Run tests and get results
+        success, test_message = run_tests()
+        
+        # Send final notification
+        send_notification(
+            status="success" if success else "failure",
+            repo=repo_name,
+            commit_sha=commit_sha,
+            token=os.environ.get('GITHUB_TOKEN'),
+            email_config={
+                "recipient": recipient_email,
+                "smtp_server": os.environ.get('SMTP_SERVER'),
+                "smtp_port": int(os.environ.get('SMTP_PORT', 587)),
+                "sender_email": os.environ.get('SENDER_EMAIL'),
+                "sender_password": os.environ.get('EMAIL_PASSWORD')
+            },
+            message=test_message
+        )
+        
+        return jsonify({
+            "message": "Pull request event processed.",
+            "test_success": success,
+            "test_message": test_message
+        }), 200
+        
+    except Exception as e:
+        logging.error(f"Error processing pull request event: {str(e)}")
+        return jsonify({"error": str(e)}), 500
 
-# Placeholder for compilation feature
 def compile_project():
     """Placeholder: Compiles the project when a commit is pushed."""
     logging.info("Compiling project...")
     pass
 
-# Placeholder for running tests
 def run_tests():
     """Placeholder: Runs automated tests and returns the result."""
     logging.info("Running tests...")
-    return "success"  # Replace with actual test execution logic
+    return True, "Tests completed successfully"  # Replace with actual test execution logic


### PR DESCRIPTION
This change allows us to update commit statuses based on the testing results. Right now, the result is always "success" as we await the testing part to be done.

Note that the email functionality has been left in, for possible future use.

This was done in cooperation with @KWJ222 